### PR TITLE
Resolved comments from 2nd review

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -100,9 +100,9 @@ RUN apk add --no-cache \
     && apk del .build-dependencies \
     && rm -rf /usr/src/arp-scan
 
-# PicoTTS - it has no specific version - use current master branch commit
-ARG PICOTTS_HASH=e3ba46009ee868911fa0b53db672a55f9cc13b1c
-RUN apk add --no-cache --virtual .build-dependencies automake autoconf git libtool popt-dev build-base \ 
+# PicoTTS - it has no specific version - commit should be taken from build.json
+ARG PICOTTS_HASH
+RUN apk add --no-cache --virtual .build-dependencies automake autoconf libtool popt-dev build-base \ 
     && git clone https://github.com/naggety/picotts.git pico \
     && cd pico \
     && git reset --hard ${PICOTTS_HASH} \
@@ -111,9 +111,8 @@ RUN apk add --no-cache --virtual .build-dependencies automake autoconf git libto
     && ./configure \
     && make \
     && make install \
-    && cd ../.. \
-    && rm -rf /usr/src/pico \
-    && apk del .build-dependencies
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/pico
 
 # Telldus
 RUN apk add --no-cache \

--- a/base/build.json
+++ b/base/build.json
@@ -1,5 +1,6 @@
 {
   "image": "homeassistant/{arch}-homeassistant-base",
+  "picotts_hash": "e3ba46009ee868911fa0b53db672a55f9cc13b1c",
   "build_from": {
     "aarch64": "homeassistant/aarch64-base-python:3.8-alpine3.12",
     "armhf": "homeassistant/armhf-base-python:3.8-alpine3.12",


### PR DESCRIPTION
In order to produce a better pipeline build, the picotts_hash shall be taken form the build.json file.
The removal phase is now optimised as suggested by the reviewer